### PR TITLE
Fix image scaling for display_avatar

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -25,17 +25,17 @@
 // GLOBAL CLASS STYLES
 .bold {
   font-weight: bold;
- }
+}
 
- .italic {
+.italic {
   font-style: italic;
- }
+}
 
- .underline {
+.underline {
   text-decoration: underline;
- }
+}
 
- .hide {
+.hide {
   height: 0;
   width: 0;
   visibility: hidden;

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -38,7 +38,7 @@
             </li>
             <li class="nav-item me-lg-3">
               <a href="#" class="d-block link-dark text-decoration-none dropdown-toggle" id="dropdownUser1" data-bs-toggle="dropdown" aria-expanded="false">
-                <%= image_tag current_user.profile.decorate.display_avatar, class: 'header-profile rounded-circle' %>
+                <%= image_tag current_user.profile.decorate.display_avatar, class: 'header-profile rounded-circle', style: "object-fit: cover;" %>
               </a>
               <ul class="position-absolute dropdown-menu dropdown-menu-end text-small" aria-labelledby="dropdownUser1" style="">
                 <li><%= link_to 'My Profile', profile_path(current_user.username), class: 'dropdown-item' %></li>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -2,7 +2,7 @@
   <%= form.error_notification %>
 
     <%= form.input :display_name, hint: 'You can use a different display name than your username.' %>
-    <%= form.input :avatar_URL %>
+    <%= form.input :avatar_URL, hint: 'Please note that Avatar Image will automatically be contained to a 1:1 ratio.' %>
     <%= form.input :about_me %>
     <%= form.input :date_of_birth, as: :date, 
                                    start_year: Date.today.year - 90,

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -13,7 +13,7 @@
         <div class="card">
           <div class="rounded-top text-white d-flex flex-row" style="background-color: #000; height:200px;">
             <div class="ms-4 mt-5 d-flex flex-column" style="width: 150px;">
-              <img src="<%= @profile.display_avatar %>" alt="Profile Photo" class="img-fluid img-thumbnail mt-4 mb-2" style="width: 150px; z-index: 1">
+              <img src="<%= @profile.display_avatar %>" alt="Profile Photo" class="img-fluid img-thumbnail mt-4 mb-2" style="width: 150px; height: 150px; z-index: 1; object-fit: cover;">
                 <%= link_to 'Edit profile', edit_profile_path(@profile.username), class: 'btn btn-outline-dark profile-edit' %>
             </div>
             <div class="ms-3" style="margin-top: 130px;">


### PR DESCRIPTION
Add `object-fit: cover` to display_avatar in profile and header. No change on comments.
Note: Not supported on IE. 98.04% as of [10/09/21](https://caniuse.com/object-fit)
Reference: https://www.digitalocean.com/community/tutorials/css-cropping-images-object-fit

**Before:**
<img src="https://user-images.githubusercontent.com/66746718/136662668-36939a53-44a1-4fe5-a6bf-2c3c6bd2589a.png" width=50% height=50%>


**After:**
<img src="https://user-images.githubusercontent.com/66746718/136662508-ad2fc343-75f5-4853-b1a9-b1f22cc1d368.png" width=50% height=50%>
